### PR TITLE
check that dir exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,11 +105,15 @@ pyinstall:
 	$(PYTHON) setup.py install --prefix=$(PREFIX)
 cleancxx:
 	for dirs in $(SUBDIRS); do\
-		$(MAKE) -C $$dirs cleancxx;\
+	        if [ -d $$dirs ]; then \
+	           $(MAKE) -C $$dirs cleancxx;\
+		fi; \
 	done
 clean:
 	for dirs in $(SUBDIRS); do\
-		$(MAKE) -C $$dirs clean;\
+	        if [ -d $$dirs ]; then \
+	           $(MAKE) -C $$dirs clean;\
+		fi; \
 	done
 	rm -f setup_local.py
 


### PR DESCRIPTION
This PR avoids a error when `clean` is run and the `mfem/ser` or `mfem/par` dirs don't exist.  Without this change running `bin/twopi install PyMFEM`, as described here:
https://github.com/SCOREC/TwoPi/blob/cwsmith/rhel7/README.rhel7.md
would fail.   Specifically, the twopi install command would output:

```
creating 'dist/PyMFEM-3.4.2-py2.7.egg' and adding 'build/bdist.linux-x86_64/egg' to it                                                                                                                                          
removing 'build/bdist.linux-x86_64/egg' (and everything under it)                                                                                                                                                               
Processing PyMFEM-3.4.2-py2.7.egg                                                                                                                                                                                               
removing '/opt/scorec/petram/mpich3.3/twopi_scorecrhel7/lib/python2.7/site-packages/PyMFEM-3.4.2-py2.7.egg' (and everything under it)                                                                                           
creating /opt/scorec/petram/mpich3.3/twopi_scorecrhel7/lib/python2.7/site-packages/PyMFEM-3.4.2-py2.7.egg                                                                                                                       
Extracting PyMFEM-3.4.2-py2.7.egg to /opt/scorec/petram/mpich3.3/twopi_scorecrhel7/lib/python2.7/site-packages                                                                                                                  
PyMFEM 3.4.2 is already the active version in easy-install.pth                                                                                                                                                                  
                                                                                                                                                                                                                                
Installed /opt/scorec/petram/mpich3.3/twopi_scorecrhel7/lib/python2.7/site-packages/PyMFEM-3.4.2-py2.7.egg                                                                                                                      
Processing dependencies for PyMFEM==3.4.2                                                                                                                                                                                       
Finished processing dependencies for PyMFEM==3.4.2                                                                                                                                                                              
TwoPiRoot:  /opt/scorec/petram/mpich3.3/twopi_scorecrhel7                                                                                                                                                                       
TwoPiDevice:  scorecrhel7                                                                                                                                                                                                       
for dirs in mfem-git/par mfem-git/ser; do\                                                                                                                                                                                      
        /usr/bin/make -C $dirs clean;\                                                                                                                                                                                          
done                                                                                                                                                                                                                            
make: *** mfem-git/par: No such file or directory.  Stop.                                                                                                                                                                       
make: *** mfem-git/ser: No such file or directory.  Stop.                                                                                                                                                                       
make: *** [clean] Error 2  
```